### PR TITLE
Fix container exiting with Exit code 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: 
      - main
+     - dev
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-FROM golang:1.22.2-bookworm as builder
+FROM golang:1.22.2-bookworm AS builder
 
 COPY go.mod go.sum ./
 RUN go mod download
 
+RUN mkdir /out
+RUN mkdir -m 1755 /out/tmp
+
 COPY *.go ./
-RUN CGO_ENABLED=0 GOOS=linux go build -o /generic-cdi-plugin
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/generic-cdi-plugin
 
 FROM scratch
 
-COPY --from=builder /generic-cdi-plugin /
+COPY --from=builder /out/. /
 
-ENTRYPOINT /generic-cdi-plugin
+ENTRYPOINT ["/generic-cdi-plugin"]


### PR DESCRIPTION
The scratch image was missing a /tmp directory. Which for some reason is needed to start the plugin.